### PR TITLE
feat: 초기 설정 및 JPA 엔티티 구현

### DIFF
--- a/src/main/java/com/example/commerce/entity/Cart.java
+++ b/src/main/java/com/example/commerce/entity/Cart.java
@@ -1,0 +1,31 @@
+package com.example.commerce.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "carts")
+public class Cart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> cartItems;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/commerce/entity/CartItem.java
+++ b/src/main/java/com/example/commerce/entity/CartItem.java
@@ -1,0 +1,34 @@
+package com.example.commerce.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "cart_items")
+public class CartItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/commerce/entity/Product.java
+++ b/src/main/java/com/example/commerce/entity/Product.java
@@ -1,0 +1,42 @@
+package com.example.commerce.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "products")
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(nullable = false)
+    private int stock;
+
+    @Lob
+    private String description;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "product")
+    private List<CartItem> cartItems;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/commerce/entity/Role.java
+++ b/src/main/java/com/example/commerce/entity/Role.java
@@ -1,0 +1,7 @@
+package com.example.commerce.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+
+}

--- a/src/main/java/com/example/commerce/entity/User.java
+++ b/src/main/java/com/example/commerce/entity/User.java
@@ -1,0 +1,41 @@
+package com.example.commerce.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String username;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Cart cart;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        if (this.role == null) {
+            this.role = Role.USER;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=commerce
+spring.datasource.url=jdbc:mysql://localhost:3306/commerce_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=gy1325846!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
**AS-IS**

- 프로젝트에 데이터베이스 연결 설정 및 JPA 엔티티가 없어 서비스 개발이 불가능한 상태였습니다.

**TO-BE**

- `application.properties` 파일에 MySQL 데이터베이스 연결 정보를 추가했습니다.
- ERD에 따라 `User`, `Product`, `Cart`, `CartItem` 엔티티와 `Role` enum 클래스를  구현했습니다.
- `spring.jpa.hibernate.ddl-auto=update` 설정을 통해 애플리케이션 실행 시 데이터베이스 테이블이 자동으로 생성되도록 했습니다.

**테스트**

- 애플리케이션을 실행하고 콘솔 로그에서 `create table` 쿼리가 정상적으로 출력되는 것을 확인했습니다.
- MySQL Workbench에서 `commerce_db` 데이터베이스에 `users`, `products`, `carts`, `cart_items` 테이블이 생성되었음을 확인했습니다.