### PR TITLE
feat: 상품 검색 API 추가 및 ProductControllerTest 전반 개선

### DIFF
--- a/src/main/java/com/example/commerce/controller/ProductController.java
+++ b/src/main/java/com/example/commerce/controller/ProductController.java
@@ -7,6 +7,10 @@ import com.example.commerce.entity.Product;
 import com.example.commerce.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -41,5 +45,16 @@ public class ProductController {
     public ResponseEntity<Product> deleteProduct(@PathVariable Long productId){
         Product deleteProduct = productService.deleteProduct(productId);
         return ResponseEntity.ok(deleteProduct);
+    }
+
+    //상품검색
+    @GetMapping("/search")
+    public ResponseEntity<Page<ProductResponse>> searchProducts(
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<ProductResponse> dtoPage = productService.searchProducts(keyword, pageable);
+
+        return ResponseEntity.ok(dtoPage);
     }
 }

--- a/src/main/java/com/example/commerce/dto/ProductSearchRequest.java
+++ b/src/main/java/com/example/commerce/dto/ProductSearchRequest.java
@@ -1,0 +1,16 @@
+package com.example.commerce.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+
+
+@Getter
+@Setter
+public class ProductSearchRequest {
+
+    private String keyword;
+    private Pageable pageable;
+}

--- a/src/main/java/com/example/commerce/repository/ProductRepository.java
+++ b/src/main/java/com/example/commerce/repository/ProductRepository.java
@@ -1,10 +1,13 @@
 package com.example.commerce.repository;
 
 import com.example.commerce.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product,Long> {
 
+    Page<Product> findByNameContainingIgnoreCaseAndIsDeletedFalse(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/example/commerce/service/ProductService.java
+++ b/src/main/java/com/example/commerce/service/ProductService.java
@@ -1,11 +1,14 @@
 package com.example.commerce.service;
 
 import com.example.commerce.dto.ProductCreateRequest;
+import com.example.commerce.dto.ProductResponse;
 import com.example.commerce.dto.ProductUpdateRequest;
 import com.example.commerce.entity.Product;
 import com.example.commerce.repository.ProductRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,5 +51,14 @@ public class ProductService {
                 .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 상품을 찾을수 없음 : " + productId));
         product.softDelete();
         return product;
+    }
+
+    //상품검색
+    @Transactional(readOnly = true)
+    public Page<ProductResponse> searchProducts(String keyword, Pageable pageable){
+
+        Page<Product> productPage = productRepository.findByNameContainingIgnoreCaseAndIsDeletedFalse(keyword, pageable);
+
+        return productPage.map(ProductResponse::new);
     }
 }

--- a/src/test/java/com/example/commerce/controller/ProductControllerTest.java
+++ b/src/test/java/com/example/commerce/controller/ProductControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.commerce.controller;
 
 import com.example.commerce.dto.ProductCreateRequest;
+import com.example.commerce.dto.ProductResponse;
 import com.example.commerce.dto.ProductUpdateRequest;
 import com.example.commerce.entity.Product;
 import com.example.commerce.service.ProductService;
@@ -11,10 +12,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -33,6 +45,25 @@ class ProductControllerTest {
     @MockBean
     private ProductService productService;
 
+    private final LocalDateTime now = LocalDateTime.now();
+
+    private Product setBaseTimeEntityFields(Product product, LocalDateTime createdDate, LocalDateTime lastModifiedDate) {
+        try {
+
+            Field createdDateField = product.getClass().getSuperclass().getDeclaredField("createdDate");
+            createdDateField.setAccessible(true);
+            createdDateField.set(product, createdDate);
+
+
+            Field lastModifiedDateField = product.getClass().getSuperclass().getDeclaredField("lastModifiedDate");
+            lastModifiedDateField.setAccessible(true);
+            lastModifiedDateField.set(product, lastModifiedDate);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to set BaseTimeEntity fields via reflection", e);
+        }
+        return product;
+    }
+
     @Test
     @DisplayName("관리자 권한으로 상품 등록 성공")
     @WithMockUser(roles = "ADMIN")
@@ -44,14 +75,17 @@ class ProductControllerTest {
         request.setStock(50);
         request.setDescription("싱싱한 사과입니다.");
 
-        // Mocking
+
         Product product = Product.builder()
                 .id(1L)
                 .name(request.getName())
                 .price(request.getPrice())
                 .stock(request.getStock())
                 .description(request.getDescription())
+                .isDeleted(false)
                 .build();
+        setBaseTimeEntityFields(product, now, now);
+
         given(productService.createProduct(any(ProductCreateRequest.class))).willReturn(product);
 
         //when then
@@ -60,7 +94,8 @@ class ProductControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.name").value("사과"))
-                .andExpect(jsonPath("$.price").value(1000));
+                .andExpect(jsonPath("$.price").value(1000))
+                .andExpect(jsonPath("$.deleted").value(false));
     }
 
     @Test
@@ -86,30 +121,35 @@ class ProductControllerTest {
     @WithMockUser(roles = "ADMIN")
     void testUpdateProduct_Success() throws Exception {
         // given
+        Long productId = 1L;
         ProductUpdateRequest request = new ProductUpdateRequest();
         request.setName("수정된 상품");
         request.setPrice(30000);
         request.setStock(10);
         request.setDescription("수정된 상품 설명");
 
+
         Product updatedProduct = Product.builder()
-                .id(1L)
+                .id(productId)
                 .name(request.getName())
                 .price(request.getPrice())
                 .stock(request.getStock())
                 .description(request.getDescription())
+                .isDeleted(false)
                 .build();
+        setBaseTimeEntityFields(updatedProduct, now.minusDays(1), now);
 
-        // Mocking
-        given(productService.updateProduct(any(Long.class), any(ProductUpdateRequest.class))).willReturn(updatedProduct);
+        given(productService.updateProduct(eq(productId), any(ProductUpdateRequest.class))).willReturn(updatedProduct);
 
         // when & then
-        mockMvc.perform(put("/products/{productId}", 1L)
+        mockMvc.perform(put("/api/products/{productId}", productId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("수정된 상품"))
-                .andExpect(jsonPath("$.price").value(30000));
+                .andExpect(jsonPath("$.price").value(30000))
+                .andExpect(jsonPath("$.id").value(productId))
+                .andExpect(jsonPath("$.deleted").value(false));
     }
 
     @Test
@@ -124,31 +164,33 @@ class ProductControllerTest {
         request.setDescription("설명");
 
         // when  then
-        mockMvc.perform(put("/products/{productId}", 1L)
+        mockMvc.perform(put("/api/products/{productId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    @DisplayName("관리자 권한으로 상품 삭제 성공")
+    @DisplayName("관리자 권한으로 상품 삭제 성공 (200 OK, Product 반환)")
     @WithMockUser(roles = "ADMIN")
     void testDeleteProduct_Success() throws Exception {
         // given
+        Long productId = 1L;
+
         Product deletedProduct = Product.builder()
-                .id(1L)
+                .id(productId)
                 .name("일반사과")
                 .price(10000)
                 .stock(100)
                 .description("맛있는 사과")
+                .isDeleted(true)
                 .build();
-        deletedProduct.softDelete();
+        setBaseTimeEntityFields(deletedProduct, now.minusDays(2), now);
 
-        // Mocking
-        given(productService.deleteProduct(any(Long.class))).willReturn(deletedProduct);
+        given(productService.deleteProduct(eq(productId))).willReturn(deletedProduct);
 
         // when & then
-        mockMvc.perform(delete("/products/{productId}", 1L)
+        mockMvc.perform(delete("/api/products/{productId}", productId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.deleted").value(true))
@@ -159,8 +201,108 @@ class ProductControllerTest {
     @DisplayName("일반 사용자 권한으로 상품 삭제 실패 (403 Forbidden)")
     @WithMockUser(roles = "USER")
     void testDeleteProduct_Forbidden() throws Exception {
-        mockMvc.perform(delete("/products/{productId}", 1L)
+        mockMvc.perform(delete("/api/products/{productId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("상품 검색 성공 - 로그인하지 않아도 가능")
+    void testSearchProducts_Success() throws Exception {
+        // given
+        Product productApple = Product.builder()
+                .id(1L)
+                .name("사과")
+                .price(1000)
+                .stock(50)
+                .description("싱싱한 사과")
+                .isDeleted(false)
+                .build();
+        setBaseTimeEntityFields(productApple, now.minusHours(2), now.minusHours(2));
+
+        Product productPear = Product.builder()
+                .id(2L)
+                .name("배")
+                .price(2000)
+                .stock(30)
+                .description("달콤한 배")
+                .isDeleted(false)
+                .build();
+        setBaseTimeEntityFields(productPear, now.minusHours(1), now.minusHours(1));
+
+
+        List<ProductResponse> productResponses = Arrays.asList(
+                new ProductResponse(productApple),
+                new ProductResponse(productPear)
+        );
+
+        Page<ProductResponse> mockPage = new PageImpl<>(productResponses);
+
+        given(productService.searchProducts(any(String.class), any(Pageable.class)))
+                .willReturn(mockPage);
+
+        // when & then
+        mockMvc.perform(get("/api/products/search")
+                        .param("keyword", "과일")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "price,desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.content[0].name").value("사과"))
+                .andExpect(jsonPath("$.content[1].name").value("배"))
+                .andExpect(jsonPath("$.content[0].deleted").value(false))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("키워드 없이 상품 검색 성공")
+    void testSearchProducts_NoKeyword_Success() throws Exception {
+        // given
+        Product productOrange = Product.builder()
+                .id(3L)
+                .name("오렌지")
+                .price(3000)
+                .stock(40)
+                .description("새콤달콤 오렌지")
+                .isDeleted(false)
+                .build();
+        setBaseTimeEntityFields(productOrange, now.minusHours(3), now.minusHours(3));
+
+        List<ProductResponse> productResponses = List.of(new ProductResponse(productOrange));
+        Page<ProductResponse> mockPage = new PageImpl<>(productResponses);
+
+        given(productService.searchProducts(eq(null), any(Pageable.class)))
+                .willReturn(mockPage);
+
+        // when & then
+        mockMvc.perform(get("/api/products/search")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "createdDate,desc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].name").value("오렌지"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("검색 결과가 없을 경우 빈 목록 반환")
+    void testSearchProducts_NoResult_Success() throws Exception {
+        // given
+        Page<ProductResponse> emptyPage = new PageImpl<>(List.of());
+
+        given(productService.searchProducts(eq("없는 키워드"), any(Pageable.class)))
+                .willReturn(emptyPage);
+
+        // when & then
+        mockMvc.perform(get("/api/products/search")
+                        .param("keyword", "없는 키워드")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.totalElements").value(0));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

상품 검색 기능을 구현하여 사용자가 키워드 기반으로 상품을 조회할 수 있도록 했습니다.
로그인 여부와 상관없이 접근 가능하며, 페이징과 정렬 기능도 적용했습니다.

---

## 📌 주요 변경 사항

- [X] /api/products/search 엔드포인트 추가
- [X] 키워드 기반 검색 로직 구현 (ProductService, ProductRepository 연동)
- [X] 검색 결과가 없을 경우 빈 리스트 반환 처리
- [X] 페이징과 정렬 기능(Pageable) 적용

---

## ✅ 테스트

- [X] 자동화된 단위 테스트
- ProductControllerTest 에서 다양한 시나리오 테스트
- 키워드로 검색 시 예상 결과 반환
- 키워드 없이 검색 시 전체 리스트 반환
- 검색결과 없을 경우 빈 리스트 반환

- [X] 수동테스트(Postman)
- 검색 API 호출 시 정상적으로 상품 조회되는지 확인
- 페이징 및 정렬 기능이 의도대로 작동하는지 확인
- 
<img width="782" height="809" alt="화면 캡처 2025-09-12 161907" src="https://github.com/user-attachments/assets/a35ed4af-2081-42b9-96ab-8a3cdf50f1b8" />

---


## 💡 추가 정보

- 검색 기능은 향후 카테고리 필터, 가격 범위 필터 등과 연계 가능
