### PR TITLE
Feat/cart delete

### DIFF
--- a/src/main/java/com/example/commerce/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/commerce/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.example.commerce;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.getWriter().write("{\"error\":\"로그인이 필요합니다.\"}");
+    }
+}

--- a/src/main/java/com/example/commerce/config/SecurityConfig.java
+++ b/src/main/java/com/example/commerce/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.commerce.config;
 
-import com.example.commerce.CustomAuthenticationEntryPoint;
+import com.example.commerce.security.CustomAuthenticationEntryPoint;
 import com.example.commerce.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/example/commerce/config/SecurityConfig.java
+++ b/src/main/java/com/example/commerce/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.commerce.config;
 
+import com.example.commerce.CustomAuthenticationEntryPoint;
 import com.example.commerce.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +22,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -54,6 +56,9 @@ public class SecurityConfig {
 
         // JWT 필터 등록
         http.addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling()
+                .authenticationEntryPoint(customAuthenticationEntryPoint);
 
         return http.build();
     }

--- a/src/main/java/com/example/commerce/controller/CartController.java
+++ b/src/main/java/com/example/commerce/controller/CartController.java
@@ -59,6 +59,18 @@ public class CartController {
 
     }
 
+    //삭제
+    @DeleteMapping("/items/{productId}")
+    public ResponseEntity<Void> deleteCartItem(
+            @PathVariable Long productId,
+            @AuthenticationPrincipal String userEmail) {
+
+        Long userId = cartService.getUserIdByEmail(userEmail);
+        cartService.deleteCartItem(userId, productId);
+
+        return ResponseEntity.noContent().build();
+    }
+
 
 }
 

--- a/src/main/java/com/example/commerce/controller/CartController.java
+++ b/src/main/java/com/example/commerce/controller/CartController.java
@@ -2,6 +2,7 @@ package com.example.commerce.controller;
 
 import com.example.commerce.dto.CartItemAddRequest;
 import com.example.commerce.dto.CartItemResponse;
+import com.example.commerce.dto.CartItemUpdateRequest;
 import com.example.commerce.service.CartService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +40,25 @@ public class CartController {
         List<CartItemResponse> cartItems = cartService.getCartItems(userId);
         return ResponseEntity.ok(cartItems);
     }
+
+    //수량수정
+    @PutMapping("/items/{productId}")
+    public ResponseEntity<CartItemResponse> updateCartItemQuantity(
+            @PathVariable Long productId,
+            @Valid @RequestBody CartItemUpdateRequest cartItemUpdateRequest,
+            @AuthenticationPrincipal String userEmail){
+
+        Long userId = cartService.getUserIdByEmail(userEmail);
+        CartItemResponse updatedItem = cartService.updateCartItemQuantity(
+                userId,
+                productId,
+                cartItemUpdateRequest.getQuantity()
+        );
+
+        return ResponseEntity.ok(updatedItem);
+
+    }
+
+
 }
 

--- a/src/main/java/com/example/commerce/controller/CartController.java
+++ b/src/main/java/com/example/commerce/controller/CartController.java
@@ -8,10 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/cart")
@@ -20,6 +19,7 @@ public class CartController {
 
     private final CartService cartService;
 
+    //담기
     @PostMapping("/items")
     public ResponseEntity<CartItemResponse> addCartItem(
             @AuthenticationPrincipal String userEmail,
@@ -29,4 +29,15 @@ public class CartController {
         CartItemResponse cartItemResponse = cartService.addCartItem(userId, cartItemAddRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(cartItemResponse);
     }
+
+    //조회
+    @GetMapping("/items")
+    public ResponseEntity<List<CartItemResponse>> getCartItems(
+            @AuthenticationPrincipal String userEmail){
+
+        Long userId = cartService.getUserIdByEmail(userEmail);
+        List<CartItemResponse> cartItems = cartService.getCartItems(userId);
+        return ResponseEntity.ok(cartItems);
+    }
 }
+

--- a/src/main/java/com/example/commerce/controller/CartController.java
+++ b/src/main/java/com/example/commerce/controller/CartController.java
@@ -1,0 +1,32 @@
+package com.example.commerce.controller;
+
+import com.example.commerce.dto.CartItemAddRequest;
+import com.example.commerce.dto.CartItemResponse;
+import com.example.commerce.service.CartService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @PostMapping("/items")
+    public ResponseEntity<CartItemResponse> addCartItem(
+            @AuthenticationPrincipal String userEmail,
+            @Valid @RequestBody CartItemAddRequest cartItemAddRequest){
+
+        Long userId = cartService.getUserIdByEmail(userEmail);
+        CartItemResponse cartItemResponse = cartService.addCartItem(userId, cartItemAddRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(cartItemResponse);
+    }
+}

--- a/src/main/java/com/example/commerce/dto/CartItemAddRequest.java
+++ b/src/main/java/com/example/commerce/dto/CartItemAddRequest.java
@@ -1,0 +1,18 @@
+package com.example.commerce.dto;
+
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CartItemAddRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+    @Min(value = 1, message = "수량은 최소 1 개 이상이어야 합니다.")
+    private int quantity;
+}

--- a/src/main/java/com/example/commerce/dto/CartItemResponse.java
+++ b/src/main/java/com/example/commerce/dto/CartItemResponse.java
@@ -1,0 +1,24 @@
+package com.example.commerce.dto;
+
+import com.example.commerce.entity.CartItem;
+import lombok.Getter;
+
+@Getter
+public class CartItemResponse {
+
+    private Long id;
+    private Long productId;
+    private String productName;
+    private int quantity;
+    private int price;
+    private int totalPrice;
+
+    public CartItemResponse(CartItem cartItem) {
+        this.id = cartItem.getId();
+        this.productId = cartItem.getProduct().getId();
+        this.productName = cartItem.getProduct().getName();
+        this.quantity = cartItem.getQuantity();
+        this.price = cartItem.getProduct().getPrice();
+        this.totalPrice = this.price * this.quantity;
+    }
+}

--- a/src/main/java/com/example/commerce/dto/CartItemUpdateRequest.java
+++ b/src/main/java/com/example/commerce/dto/CartItemUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.example.commerce.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CartItemUpdateRequest {
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+    private int quantity;
+}

--- a/src/main/java/com/example/commerce/repository/CartItemRepository.java
+++ b/src/main/java/com/example/commerce/repository/CartItemRepository.java
@@ -1,12 +1,16 @@
 package com.example.commerce.repository;
 
+import com.example.commerce.entity.Cart;
 import com.example.commerce.entity.CartItem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface CartItemRepository extends JpaRepository<CartItem,Long> {
 
-    Optional<CartItem> findbyCartInAndProductId(Long cartId, Long productId);
+    Optional<CartItem> findByCartAndProductId(Cart cart, Long productId);
+
+
 }

--- a/src/main/java/com/example/commerce/repository/CartItemRepository.java
+++ b/src/main/java/com/example/commerce/repository/CartItemRepository.java
@@ -1,0 +1,12 @@
+package com.example.commerce.repository;
+
+import com.example.commerce.entity.CartItem;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem,Long> {
+
+    Optional<CartItem> findbyCartInAndProductId(Long cartId, Long productId);
+}

--- a/src/main/java/com/example/commerce/repository/CartRepository.java
+++ b/src/main/java/com/example/commerce/repository/CartRepository.java
@@ -1,0 +1,11 @@
+package com.example.commerce.repository;
+
+import com.example.commerce.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart,Long> {
+
+    Optional<Cart> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/commerce/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/commerce/security/CustomAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.example.commerce;
+package com.example.commerce.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/example/commerce/service/CartService.java
+++ b/src/main/java/com/example/commerce/service/CartService.java
@@ -1,0 +1,72 @@
+package com.example.commerce.service;
+
+
+import com.example.commerce.dto.CartItemAddRequest;
+import com.example.commerce.dto.CartItemResponse;
+import com.example.commerce.entity.Cart;
+import com.example.commerce.entity.CartItem;
+import com.example.commerce.entity.Product;
+import com.example.commerce.entity.User;
+import com.example.commerce.repository.CartItemRepository;
+import com.example.commerce.repository.CartRepository;
+import com.example.commerce.repository.ProductRepository;
+import com.example.commerce.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CartItemResponse addCartItem(Long userId, CartItemAddRequest cartItemAddRequest) {
+
+        //사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을수 없음"));
+
+        //사용자 장바구니를 조회하고 없으면 새로 생성
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseGet(() -> {
+                    Cart newCart = new Cart();
+                    newCart.setUser(user);
+                    return cartRepository.save(newCart);
+                });
+
+        //상품 조회
+        Product product = productRepository.findById(cartItemAddRequest.getProductId())
+                .orElseThrow(() -> new EntityNotFoundException("상품을 찾을수없음"));
+
+        //상품 검증
+        if (product.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 상품은 담을수 없음");
+        }
+        if (cartItemAddRequest.getQuantity() > product.getStock()) {
+            throw new IllegalArgumentException("상품 재고가 부족함");
+        }
+
+        //CartItem 조회하고 이미 담겼으면 수량을 누적
+        CartItem cartItem = cartItemRepository.findbyCartInAndProductId(cart.getId(), product.getId())
+                .orElseGet(() -> {
+                    CartItem newItem = new CartItem();
+                    newItem.setCart(cart);
+                    newItem.setProduct(product);
+                    newItem.setQuantity(0);
+                    return newItem;
+                });
+
+        //수량을 누적
+        cartItem.setQuantity(cartItem.getQuantity() +cartItemAddRequest.getQuantity());
+
+        cartItemRepository.save(cartItem);
+
+        return new CartItemResponse(cartItem);
+    }
+}

--- a/src/main/java/com/example/commerce/service/CartService.java
+++ b/src/main/java/com/example/commerce/service/CartService.java
@@ -25,6 +25,13 @@ public class CartService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
+    public Long getUserIdByEmail(String email){
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을수 없음"));
+        return user.getId();
+    }
+
     @Transactional
     public CartItemResponse addCartItem(Long userId, CartItemAddRequest cartItemAddRequest) {
 
@@ -53,7 +60,7 @@ public class CartService {
         }
 
         //CartItem 조회하고 이미 담겼으면 수량을 누적
-        CartItem cartItem = cartItemRepository.findbyCartInAndProductId(cart.getId(), product.getId())
+        CartItem cartItem = cartItemRepository.findByCartAndProductId(cart, product.getId())
                 .orElseGet(() -> {
                     CartItem newItem = new CartItem();
                     newItem.setCart(cart);

--- a/src/main/java/com/example/commerce/service/CartService.java
+++ b/src/main/java/com/example/commerce/service/CartService.java
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CartService {
@@ -75,5 +78,16 @@ public class CartService {
         cartItemRepository.save(cartItem);
 
         return new CartItemResponse(cartItem);
+    }
+
+    //장바구니 전체 조회
+    @Transactional(readOnly = true)
+    public List<CartItemResponse> getCartItems(Long userId) {
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("장바구니가 존재하지 않음"));
+
+        return cart.getCartItems().stream()
+                .map(CartItemResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/commerce/service/CartService.java
+++ b/src/main/java/com/example/commerce/service/CartService.java
@@ -118,4 +118,21 @@ public class CartService {
 
         return new CartItemResponse(cartItem);
     }
+
+    //삭제
+    @Transactional
+    public void deleteCartItem(Long userId, Long productId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없음"));
+
+        // 장바구니 조회
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("장바구니가 존재하지 않음"));
+
+        // CartItem 조회
+        CartItem cartItem = cartItemRepository.findByCartAndProductId(cart, productId)
+                .orElseThrow(() -> new EntityNotFoundException("장바구니에 해당 상품이 없음"));
+
+        cartItemRepository.delete(cartItem);
+    }
 }

--- a/src/main/java/com/example/commerce/service/CartService.java
+++ b/src/main/java/com/example/commerce/service/CartService.java
@@ -90,4 +90,32 @@ public class CartService {
                 .map(CartItemResponse::new)
                 .collect(Collectors.toList());
     }
+
+    //장바구니 수량수정
+    @Transactional
+    public CartItemResponse updateCartItemQuantity(Long userId, Long productId, int newQuantity) {
+        if (newQuantity <= 0) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없음"));
+
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("장바구니가 존재하지 않음"));
+
+        CartItem cartItem = cartItemRepository.findByCartAndProductId(cart, productId)
+                .orElseThrow(() -> new EntityNotFoundException("장바구니에 해당 상품이 없음"));
+
+        Product product = cartItem.getProduct();
+
+        if (newQuantity > product.getStock()) {
+            throw new IllegalArgumentException("상품 재고보다 많은 수량을 입력하세요");
+        }
+
+        cartItem.setQuantity(newQuantity);
+        cartItemRepository.save(cartItem);
+
+        return new CartItemResponse(cartItem);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

장바구니에서 특정 상품을 삭제할수있는 기능을 구현했습니다.

---

## 📌 주요 변경 사항

- [X] DELETE  /api/cart/items/{productId} 엔드포인트 추가
- [X] CartService 에 deleteCartItem 메서드 구현
- userId와 productId를 기반으로 사용자의 장바구니와 해당 장바구니 아이템을 조회합니다.
- EntityNotFoundException을 통해 장바구니나 상품이 없는 경우 적절한 예외를 발생시킵니다.
- cartItemRepository.delete(cartItem)을 호출하여 데이터베이스에서 CartItem 레코드를 삭제합니다.


---

## ✅ 테스트

- [ ] 자동화된 테스트
- [X] 수동테스트 (Postman, H2)
- DELETE http://localhost:8080/api/cart/items/{상품ID} 요청을 보낸 후 204 응답 확인
- 상품 삭제 후 장바구니 조회결과 [] 빈배열 확인
-
<img width="574" height="440" alt="화면 캡처 2025-09-16 172710" src="https://github.com/user-attachments/assets/ca1d6744-b07d-479a-98a7-25dc094778b7" />
<img width="571" height="399" alt="화면 캡처 2025-09-16 171608" src="https://github.com/user-attachments/assets/c47e294f-55cc-4ebd-98ae-369e50e88949" />



---


## 💡 추가 정보


