### PR TITLE
Feat/order creation

### DIFF
--- a/src/main/java/com/example/commerce/config/SecurityConfig.java
+++ b/src/main/java/com/example/commerce/config/SecurityConfig.java
@@ -44,6 +44,9 @@ public class SecurityConfig {
                         // 장바구니 (로그인 사용자만)
                         .requestMatchers(new AntPathRequestMatcher("/api/cart/**")).hasAnyRole("USER", "ADMIN")
 
+                        // 주문 (로그인 사용자만)
+                        .requestMatchers(new AntPathRequestMatcher("/api/orders/**")).hasAnyRole("USER", "ADMIN")
+
                         // H2 콘솔
                         .requestMatchers(new AntPathRequestMatcher("/h2-console/**")).permitAll()
 

--- a/src/main/java/com/example/commerce/controller/CartController.java
+++ b/src/main/java/com/example/commerce/controller/CartController.java
@@ -35,8 +35,7 @@ public class CartController {
     public ResponseEntity<List<CartItemResponse>> getCartItems(
             @AuthenticationPrincipal String userEmail){
 
-        Long userId = cartService.getUserIdByEmail(userEmail);
-        List<CartItemResponse> cartItems = cartService.getCartItems(userId);
+        List<CartItemResponse> cartItems = cartService.getCartItems(userEmail);
         return ResponseEntity.ok(cartItems);
     }
 
@@ -47,9 +46,9 @@ public class CartController {
             @Valid @RequestBody CartItemUpdateRequest cartItemUpdateRequest,
             @AuthenticationPrincipal String userEmail){
 
-        Long userId = cartService.getUserIdByEmail(userEmail);
+
         CartItemResponse updatedItem = cartService.updateCartItemQuantity(
-                userId,
+                userEmail,
                 productId,
                 cartItemUpdateRequest.getQuantity()
         );
@@ -64,8 +63,8 @@ public class CartController {
             @PathVariable Long productId,
             @AuthenticationPrincipal String userEmail) {
 
-        Long userId = cartService.getUserIdByEmail(userEmail);
-        cartService.deleteCartItem(userId, productId);
+
+        cartService.deleteCartItem(userEmail, productId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/commerce/controller/OrderController.java
+++ b/src/main/java/com/example/commerce/controller/OrderController.java
@@ -1,0 +1,33 @@
+package com.example.commerce.controller;
+
+import com.example.commerce.dto.OrderCreateRequest;
+import com.example.commerce.dto.OrderResponse;
+import com.example.commerce.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    //주문생성
+    @PostMapping
+    public ResponseEntity<OrderResponse> createOrder(
+            @AuthenticationPrincipal String userEmail,
+            @Valid @RequestBody OrderCreateRequest orderCreateRequest) {
+
+        OrderResponse orderResponse = orderService.createOrder(userEmail, orderCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
+    }
+
+}

--- a/src/main/java/com/example/commerce/dto/OrderCreateRequest.java
+++ b/src/main/java/com/example/commerce/dto/OrderCreateRequest.java
@@ -1,0 +1,24 @@
+package com.example.commerce.dto;
+
+import com.example.commerce.entity.PaymentMethod;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrderCreateRequest {
+
+    @NotBlank(message = "수령인의 이름은 필수입니다.")
+    private String recipientName;
+
+    @NotBlank(message = "수령인의 전화번호는 필수입니다.")
+    private String recipientPhone;
+
+    @NotBlank(message = "배송주소는 필수입니다.")
+    private String recipientAddress;
+
+    @NotNull(message = "결제수단은 필수입니다.")
+    private PaymentMethod paymentMethod;
+}

--- a/src/main/java/com/example/commerce/dto/OrderItemResponse.java
+++ b/src/main/java/com/example/commerce/dto/OrderItemResponse.java
@@ -1,0 +1,22 @@
+package com.example.commerce.dto;
+
+import com.example.commerce.entity.OrderItem;
+import lombok.Getter;
+
+@Getter
+public class OrderItemResponse {
+    private Long productId;
+    private String productName;
+    private int productPrice;
+    private int quantity;
+    private int itemAmount;
+
+    public OrderItemResponse(OrderItem orderItem) {
+
+        this.productId = orderItem.getProductId();
+        this.productName = orderItem.getProductName();
+        this.productPrice = orderItem.getProductPrice();
+        this.quantity = orderItem.getQuantity();
+        this.itemAmount = orderItem.calculateItemAmount();
+    }
+}

--- a/src/main/java/com/example/commerce/dto/OrderResponse.java
+++ b/src/main/java/com/example/commerce/dto/OrderResponse.java
@@ -1,0 +1,40 @@
+package com.example.commerce.dto;
+
+import com.example.commerce.entity.Order;
+import com.example.commerce.entity.OrderStatus;
+import com.example.commerce.entity.PaymentMethod;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class OrderResponse {
+    private Long orderId;
+    private String userEmail;
+    private int totalAmount;
+    private OrderStatus orderStatus;
+    private PaymentMethod paymentMethod;
+    private String recipientName;
+    private String recipientPhone;
+    private String deliveryAddress;
+    private LocalDateTime orderDate;
+
+    private List<OrderItemResponse> orderItems;
+
+    public OrderResponse(Order order) {
+        this.orderId = order.getId();
+        this.userEmail= order.getUser().getEmail();
+        this.totalAmount = order.getTotalAmount();
+        this.orderStatus = order.getOrderStatus();
+        this.paymentMethod = order.getPaymentMethod();
+        this.recipientName = order.getRecipientName();
+        this.recipientPhone = order.getRecipientPhone();
+        this.deliveryAddress = order.getDeliveryAddress();
+        this.orderDate = order.getOrderDate();
+        this.orderItems = order.getOrderItems().stream()
+                .map(OrderItemResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/commerce/entity/Order.java
+++ b/src/main/java/com/example/commerce/entity/Order.java
@@ -1,0 +1,63 @@
+package com.example.commerce.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private int totalAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus orderStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentMethod paymentMethod;
+
+    @Column(nullable = false)
+    private String recipientName;
+    @Column(nullable = false)
+    private String recipientPhone;
+    @Column(nullable = false)
+    private String deliveryAddress;
+
+    private LocalDateTime orderDate;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        this.orderDate = LocalDateTime.now();
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        orderItems.add(orderItem);
+        orderItem.setOrder(this);
+    }
+
+    public void changeStatus(OrderStatus newStatus) {
+        this.orderStatus = newStatus;
+    }
+}

--- a/src/main/java/com/example/commerce/entity/OrderItem.java
+++ b/src/main/java/com/example/commerce/entity/OrderItem.java
@@ -1,0 +1,36 @@
+package com.example.commerce.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderItem extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Column(nullable = false)
+    private Long productId;
+    @Column(nullable = false)
+    private String productName;
+    @Column(nullable = false)
+    private int productPrice;
+    @Column(nullable = false)
+    private int quantity;
+
+    public int calculateItemAmount() {
+        return this.productPrice * this.quantity;
+    }
+}

--- a/src/main/java/com/example/commerce/entity/OrderItem.java
+++ b/src/main/java/com/example/commerce/entity/OrderItem.java
@@ -2,7 +2,7 @@ package com.example.commerce.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.Id;
+
 
 @Entity
 @Table(name = "order_items")

--- a/src/main/java/com/example/commerce/entity/OrderStatus.java
+++ b/src/main/java/com/example/commerce/entity/OrderStatus.java
@@ -1,0 +1,9 @@
+package com.example.commerce.entity;
+
+public enum OrderStatus {
+    PENDING,
+    PAID,
+    SHIPPING,
+    DELIVERD,
+    CANCELLED
+}

--- a/src/main/java/com/example/commerce/entity/PaymentMethod.java
+++ b/src/main/java/com/example/commerce/entity/PaymentMethod.java
@@ -1,0 +1,9 @@
+package com.example.commerce.entity;
+
+public enum PaymentMethod {
+    CREDIT_CARD,
+    BANK_TRANSFER,
+    KAKAO_PAY,
+    TOSS_PAY,
+    NAVER_PAY
+}

--- a/src/main/java/com/example/commerce/entity/Product.java
+++ b/src/main/java/com/example/commerce/entity/Product.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,6 +40,16 @@ public class Product extends BaseTimeEntity {
         this.isDeleted = true;
     }
 
+    public void decreaseStock(int quantity) {
+        if (this.stock < quantity) {
+            throw new IllegalArgumentException("상품 '" + this.name + "'의 재고(" + this.stock + ")가 부족하여 " + quantity + "개 감소시킬 수 없습니다.");
+        }
+        this.stock -= quantity;
+    }
+
+    public void increaseStock(int quantity) {
+        this.stock += quantity;
+    }
 
 
 }

--- a/src/main/java/com/example/commerce/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/commerce/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.commerce.repository;
+
+import com.example.commerce.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem,Long> {
+}

--- a/src/main/java/com/example/commerce/repository/OrderRepository.java
+++ b/src/main/java/com/example/commerce/repository/OrderRepository.java
@@ -1,0 +1,15 @@
+package com.example.commerce.repository;
+
+
+import com.example.commerce.entity.Order;
+import com.example.commerce.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order,Long> {
+    List<Order> findByUser(User user);
+
+    Optional<Order> findByIdAndUser(Long orderId, User user);
+}

--- a/src/main/java/com/example/commerce/service/CartService.java
+++ b/src/main/java/com/example/commerce/service/CartService.java
@@ -13,7 +13,6 @@ import com.example.commerce.repository.ProductRepository;
 import com.example.commerce.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +28,7 @@ public class CartService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
     private final UserService userService;
-    private final EmailValidator emailValidator;
+
 
 
     @Transactional

--- a/src/main/java/com/example/commerce/service/OrderService.java
+++ b/src/main/java/com/example/commerce/service/OrderService.java
@@ -1,0 +1,79 @@
+package com.example.commerce.service;
+
+import com.example.commerce.dto.OrderCreateRequest;
+import com.example.commerce.dto.OrderResponse;
+import com.example.commerce.entity.*;
+import com.example.commerce.repository.*;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+
+    private final UserService userService;
+
+    @Transactional
+    public OrderResponse createOrder(String userEmail, OrderCreateRequest orderCreateRequest) {
+
+        User user = userService.getUserByEmail(userEmail);
+
+        Cart userCart = cartRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new EntityNotFoundException("사용자의 장바구니를 찾을 수 없습니다."));
+
+        List<CartItem> cartItems = userCart.getCartItems();
+
+        if (cartItems.isEmpty()) {
+            throw new IllegalArgumentException("장바구니에 상품이 없습니다. 주문할 상품을 추가해주세요.");
+        }
+
+        Order newOrder = Order.builder()
+                .user(user)
+                .orderStatus(OrderStatus.PENDING)
+                .paymentMethod(orderCreateRequest.getPaymentMethod())
+                .recipientName(orderCreateRequest.getRecipientName())
+                .recipientPhone(orderCreateRequest.getRecipientPhone())
+                .deliveryAddress(orderCreateRequest.getRecipientAddress())
+                .build();
+
+        int totalOrderAmount = 0;
+
+        for (CartItem cartItem : cartItems) {
+            Product product = cartItem.getProduct();
+
+
+            product.decreaseStock(cartItem.getQuantity());
+
+            OrderItem orderItem = OrderItem.builder()
+                    .productId(product.getId())
+                    .productName(product.getName())
+                    .productPrice(product.getPrice())
+                    .quantity(cartItem.getQuantity())
+                    .build();
+
+            newOrder.addOrderItem(orderItem);
+            totalOrderAmount += orderItem.calculateItemAmount();
+        }
+
+        newOrder.setTotalAmount(totalOrderAmount);
+
+        Order savedOrder = orderRepository.save(newOrder);
+
+        cartItemRepository.deleteAll(cartItems);
+        userCart.getCartItems().clear();
+
+        return new OrderResponse(savedOrder);
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용

사용자의 장바구니에 담긴 상품들을 바탕으로 주문을 생성하는 기능을 구현했습니다.
주문정보 저장, 상품 재고 감소, 장바구니 비우기 로직 포함

---

## 📌 주요 변경 사항


- [X] 주문 생성 API POST /api/orders 추가
- [X] 주문관련 비즈니스 로직 구현
- 사용자 및 장바구니 조회 (없으면 예외처리)
- 장바구니 아이템들을 주문 아이템으로 변환하여 Order 엔티티에 추가
- 각 상품의 재고를 주문 수량만큼 감소
- 최종 주문 금액 계산
- Order, OrderItem 엔티티를 데이터베이스에 저장
- 주문 완료 후 사용자의 장바구니에 담긴 모든 CartItem 삭제
- [X] 보안설정 업데이트
- /api/orders/** 경로에 대해 로그인된 사용자만 접근할 수 있도록 권한 설정 추가 

---

## ✅ 테스트


- [ ] 자동화된 테스트
- [X] 수동테스트(Postman, H2)
- 일반 사용자 토큰을 사용하여 장바구니에 상품을 추가
- 일반 사용자 토큰과 유효한 OrderCreateRequest DTO를 사용하여 POST /api/orders 요청 시 201 Created 응답과 함께 정확한 OrderResponse가 반환됨을 확인.
- 장바구니에 상품이 없는 상태에서 주문 시도 시 400 Bad Request 응답과 함께 적절한 예외 메시지가 반환됨을 확인.
<img width="588" height="770" alt="화면 캡처 2025-09-18 222115" src="https://github.com/user-attachments/assets/57a63e1a-485d-4ea6-8e68-44a46da50b18" />
<img width="1047" height="720" alt="화면 캡처 2025-09-18 223309" src="https://github.com/user-attachments/assets/3e3132c0-d56a-48d5-85d6-785aaa129826" />

---


## 💡 추가 정보

- 아직 주문 목록 조회, 특정 주문 상세 조회, 주문 취소 기능은 다음작업에 이어 구현할 예정입니다.
- 이 pr은 프로젝트 내에 하기로 한 기능을 수행한 후 추가로 작업한 것입니다.
