### PR TITLE
Feat/order view

### DIFF
--- a/src/main/java/com/example/commerce/controller/OrderController.java
+++ b/src/main/java/com/example/commerce/controller/OrderController.java
@@ -5,12 +5,13 @@ import com.example.commerce.dto.OrderResponse;
 import com.example.commerce.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -31,10 +32,12 @@ public class OrderController {
 
     //조회
     @GetMapping
-    public ResponseEntity<List<OrderResponse>> getOrders(
-            @AuthenticationPrincipal String userEmail) {
-        List<OrderResponse> orders = orderService.getOrdersByUser(userEmail);
-        return ResponseEntity.ok(orders);
+    public ResponseEntity<Page<OrderResponse>> getOrders(
+                                                          @AuthenticationPrincipal String userEmail,
+                                                          Pageable pageable) {
+
+        Page<OrderResponse> ordersPage = orderService.getOrdersByUser(userEmail, pageable);
+        return ResponseEntity.ok(ordersPage);
     }
 
     @GetMapping("/{orderId}")

--- a/src/main/java/com/example/commerce/controller/OrderController.java
+++ b/src/main/java/com/example/commerce/controller/OrderController.java
@@ -8,10 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -28,6 +27,22 @@ public class OrderController {
 
         OrderResponse orderResponse = orderService.createOrder(userEmail, orderCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
+    }
+
+    //조회
+    @GetMapping
+    public ResponseEntity<List<OrderResponse>> getOrders(
+            @AuthenticationPrincipal String userEmail) {
+        List<OrderResponse> orders = orderService.getOrdersByUser(userEmail);
+        return ResponseEntity.ok(orders);
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderResponse> getOrderDetails(
+            @AuthenticationPrincipal String userEmail,
+            @PathVariable Long orderId){
+        OrderResponse orderResponse = orderService.getOrderDetails(userEmail, orderId);
+        return ResponseEntity.ok(orderResponse);
     }
 
 }

--- a/src/main/java/com/example/commerce/repository/OrderRepository.java
+++ b/src/main/java/com/example/commerce/repository/OrderRepository.java
@@ -1,22 +1,21 @@
 package com.example.commerce.repository;
 
-
 import com.example.commerce.entity.Order;
 import com.example.commerce.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order,Long> {
-    List<Order> findByUser(User user);
-
     Optional<Order> findByIdAndUser(Long orderId, User user);
 
-    @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.user = :user")
-    List<Order> findByUserWithOrderItems(@Param("user") User user);
+    Page<Order> findByUser(User user, Pageable pageable);
+
 
     @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.id = :orderId AND o.user = :user")
     Optional<Order> findByIdAndUserWithOrderItems(@Param("orderId") Long orderId, @Param("user") User user);

--- a/src/main/java/com/example/commerce/repository/OrderRepository.java
+++ b/src/main/java/com/example/commerce/repository/OrderRepository.java
@@ -4,6 +4,8 @@ package com.example.commerce.repository;
 import com.example.commerce.entity.Order;
 import com.example.commerce.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +14,10 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
     List<Order> findByUser(User user);
 
     Optional<Order> findByIdAndUser(Long orderId, User user);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.user = :user")
+    List<Order> findByUserWithOrderItems(@Param("user") User user);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.id = :orderId AND o.user = :user")
+    Optional<Order> findByIdAndUserWithOrderItems(@Param("orderId") Long orderId, @Param("user") User user);
 }

--- a/src/main/java/com/example/commerce/service/OrderService.java
+++ b/src/main/java/com/example/commerce/service/OrderService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -74,6 +75,26 @@ public class OrderService {
         userCart.getCartItems().clear();
 
         return new OrderResponse(savedOrder);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderResponse> getOrdersByUser(String userEmail){
+        User user = userService.getUserByEmail(userEmail);
+        List<Order> orders = orderRepository.findByUserWithOrderItems(user);
+
+        return orders.stream()
+                .map(OrderResponse::new)
+                .collect(Collectors.toList());
+
+    }
+
+    @Transactional(readOnly = true)
+    public OrderResponse getOrderDetails(String userEmail, Long orderId){
+        User user = userService.getUserByEmail(userEmail);
+
+        Order order = orderRepository.findByIdAndUserWithOrderItems(orderId, user)
+                .orElseThrow(() -> new EntityNotFoundException("해당 주문을 찾을 수 없음"));
+        return new OrderResponse(order);
     }
 
 }


### PR DESCRIPTION
## 📝 작업 내용

사용자가 자신의 주문 목록을 조회하고, 특정 주문의 상세정보를 조회할 수 있는 기능을 구현했습니다.
이 과정에서 JPA N+1 문제를 해결하기 위해 Fetch Join을 적용하여 데이터 조회 효율성을 높였습니다.

---

## 📌 주요 변경 사항

- [X] 사용자 주문 목록 조회 API 추가  GET  /api/orders
- 로그인한 사용자가 자신의 모든 주문 내역을 조회할수있도록 구현
- [X] 특정주문 상세 조회 API 추가  GET  /api/orders/{orderId}
- 다른 사용자의 주문은 조회할 수 없도록 권한 검증 로직 포함
- [X] N+1 문제 해결을 위한 Fetch Join 적용 (OrderRepository, OrderService)
- OrderRepository에 findByUserWithOrderItems 및 findByIdAndUserWithOrderItems 쿼리 메소드를 추가하여, Order 엔티티 조회 시 연관된 OrderItem 엔티티들을 즉시 로딩하도록 Fetch Join을 적용했습니다.
- OrderService의 getOrdersByUser 및 getOrderDetails 메소드에서 위 Fetch Join 쿼리 메소드를 사용하도록 수정하여 N+1 문제를 방지했습니다.

---

## ✅ 테스트

- [ ] 자동화테스트
- [X] 수동테스트(Postman, H2)
- 발급받은 토큰을 사용하여 GET /api/orders 요청 시, 해당 사용자의 주문 목록이 orderItems를 포함하여 정상적으로 반환됨을 확인
- GET /api/orders/{orderId} 요청 시, 특정 주문의 상세 정보가 orderItems를 포함하여 정상적으로 반환됨을 확인
- 존재하지 않는 orderId 또는 다른 사용자의 orderId로 조회 시 404 Not Found 예외가 발생하는지 확인
<img width="1455" height="765" alt="화면 캡처 2025-09-18 225307" src="https://github.com/user-attachments/assets/9a37a889-82ca-4f29-bb79-95fb9a84c1f1" />
<img width="539" height="811" alt="화면 캡처 2025-09-18 225501" src="https://github.com/user-attachments/assets/817020c8-99dd-447f-a827-ca291df7cce7" />


---


## 💡 추가 정보

-다음 PR에서는 주문 취소 기능 구현을 진행할 예정
